### PR TITLE
WQP-1171: Indicies for data-source-specific tables should not be…

### DIFF
--- a/biodata/indexes/prjMLWeighting.yml
+++ b/biodata/indexes/prjMLWeighting.yml
@@ -13,7 +13,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_BIODATA_IDENTIFIER' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_biodata_identifier on prj_ml_weighting_swap_biodata(project_identifier) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_biodata_identifier on prj_ml_weighting_swap_biodata(project_identifier) parallel 4 nologging;
         - rollback: drop index prjmlw_biodata_identifier;
 
   - changeSet:
@@ -26,7 +26,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_BIODATA_COUNTRY' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_biodata_country on prj_ml_weighting_swap_biodata(country_code) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_biodata_country on prj_ml_weighting_swap_biodata(country_code) parallel 4 nologging;
         - rollback: drop index prjmlw_biodata_country;
 
   - changeSet:
@@ -39,7 +39,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_BIODATA_COUNTY' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_biodata_county on prj_ml_weighting_swap_biodata(county_code) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_biodata_county on prj_ml_weighting_swap_biodata(county_code) parallel 4 nologging;
         - rollback: drop index prjmlw_biodata_county;
 
   - changeSet:
@@ -52,7 +52,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_BIODATA_HUC10' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_biodata_huc10 on prj_ml_weighting_swap_biodata(huc_10) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_biodata_huc10 on prj_ml_weighting_swap_biodata(huc_10) parallel 4 nologging;
         - rollback: drop index prjmlw_biodata_huc10;
 
   - changeSet:
@@ -65,7 +65,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_BIODATA_HUC12' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_biodata_huc12 on prj_ml_weighting_swap_biodata(huc_12) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_biodata_huc12 on prj_ml_weighting_swap_biodata(huc_12) parallel 4 nologging;
         - rollback: drop index prjmlw_biodata_huc12;
 
   - changeSet:
@@ -78,7 +78,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_BIODATA_HUC2' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_biodata_huc2 on prj_ml_weighting_swap_biodata(huc_2) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_biodata_huc2 on prj_ml_weighting_swap_biodata(huc_2) parallel 4 nologging;
         - rollback: drop index prjmlw_biodata_huc2;
 
   - changeSet:
@@ -91,7 +91,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_BIODATA_HUC4' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_biodata_huc4 on prj_ml_weighting_swap_biodata(huc_4) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_biodata_huc4 on prj_ml_weighting_swap_biodata(huc_4) parallel 4 nologging;
         - rollback: drop index prjmlw_biodata_huc4;
 
   - changeSet:
@@ -104,7 +104,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_BIODATA_HUC6' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_biodata_huc6 on prj_ml_weighting_swap_biodata(huc_6) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_biodata_huc6 on prj_ml_weighting_swap_biodata(huc_6) parallel 4 nologging;
         - rollback: drop index prjmlw_biodata_huc6;
 
   - changeSet:
@@ -117,7 +117,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_BIODATA_HUC8' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_biodata_huc8 on prj_ml_weighting_swap_biodata(huc_8) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_biodata_huc8 on prj_ml_weighting_swap_biodata(huc_8) parallel 4 nologging;
         - rollback: drop index prjmlw_biodata_huc8;
 
   - changeSet:
@@ -130,7 +130,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_BIODATA_ORGANIZATION' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_biodata_organization on prj_ml_weighting_swap_biodata(organization) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_biodata_organization on prj_ml_weighting_swap_biodata(organization) parallel 4 nologging;
         - rollback: drop index prjmlw_biodata_organization;
 
   - changeSet:
@@ -143,7 +143,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_BIODATA_SITE' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_biodata_site on prj_ml_weighting_swap_biodata(site_id) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_biodata_site on prj_ml_weighting_swap_biodata(site_id) parallel 4 nologging;
         - rollback: drop index prjmlw_biodata_site;
 
   - changeSet:
@@ -156,7 +156,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_BIODATA_SITE_TYPE' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_biodata_site_type on prj_ml_weighting_swap_biodata(site_type) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_biodata_site_type on prj_ml_weighting_swap_biodata(site_type) parallel 4 nologging;
         - rollback: drop index prjmlw_biodata_site_type;
 
   - changeSet:
@@ -169,7 +169,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_BIODATA_STATE' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_biodata_state on prj_ml_weighting_swap_biodata(state_code) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_biodata_state on prj_ml_weighting_swap_biodata(state_code) parallel 4 nologging;
         - rollback: drop index prjmlw_biodata_state;
 
   - changeSet:
@@ -182,5 +182,5 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_BIODATA_STATION' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_biodata_station on prj_ml_weighting_swap_biodata(station_id) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_biodata_station on prj_ml_weighting_swap_biodata(station_id) parallel 4 nologging;
         - rollback: drop index prjmlw_biodata_station;

--- a/nwis/indexes/prjMLWeighting.yml
+++ b/nwis/indexes/prjMLWeighting.yml
@@ -13,7 +13,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_NWIS_IDENTIFIER' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_nwis_identifier on prj_ml_weighting_swap_nwis(project_identifier) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_nwis_identifier on prj_ml_weighting_swap_nwis(project_identifier) parallel 4 nologging;
         - rollback: drop index prjmlw_nwis_identifier;
 
   - changeSet:
@@ -26,7 +26,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_NWIS_COUNTRY' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_nwis_country on prj_ml_weighting_swap_nwis(country_code) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_nwis_country on prj_ml_weighting_swap_nwis(country_code) parallel 4 nologging;
         - rollback: drop index prjmlw_nwis_country;
 
   - changeSet:
@@ -39,7 +39,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_NWIS_COUNTY' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_nwis_county on prj_ml_weighting_swap_nwis(county_code) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_nwis_county on prj_ml_weighting_swap_nwis(county_code) parallel 4 nologging;
         - rollback: drop index prjmlw_nwis_county;
 
   - changeSet:
@@ -52,7 +52,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_NWIS_HUC10' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_nwis_huc10 on prj_ml_weighting_swap_nwis(huc_10) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_nwis_huc10 on prj_ml_weighting_swap_nwis(huc_10) parallel 4 nologging;
         - rollback: drop index prjmlw_nwis_huc10;
 
   - changeSet:
@@ -65,7 +65,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_NWIS_HUC12' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_nwis_huc12 on prj_ml_weighting_swap_nwis(huc_12) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_nwis_huc12 on prj_ml_weighting_swap_nwis(huc_12) parallel 4 nologging;
         - rollback: drop index prjmlw_nwis_huc12;
 
   - changeSet:
@@ -78,7 +78,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_NWIS_HUC2' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_nwis_huc2 on prj_ml_weighting_swap_nwis(huc_2) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_nwis_huc2 on prj_ml_weighting_swap_nwis(huc_2) parallel 4 nologging;
         - rollback: drop index prjmlw_nwis_huc2;
 
   - changeSet:
@@ -91,7 +91,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_NWIS_HUC4' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_nwis_huc4 on prj_ml_weighting_swap_nwis(huc_4) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_nwis_huc4 on prj_ml_weighting_swap_nwis(huc_4) parallel 4 nologging;
         - rollback: drop index prjmlw_nwis_huc4;
 
   - changeSet:
@@ -104,7 +104,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_NWIS_HUC6' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_nwis_huc6 on prj_ml_weighting_swap_nwis(huc_6) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_nwis_huc6 on prj_ml_weighting_swap_nwis(huc_6) parallel 4 nologging;
         - rollback: drop index prjmlw_nwis_huc6;
 
   - changeSet:
@@ -117,7 +117,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_NWIS_HUC8' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_nwis_huc8 on prj_ml_weighting_swap_nwis(huc_8) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_nwis_huc8 on prj_ml_weighting_swap_nwis(huc_8) parallel 4 nologging;
         - rollback: drop index prjmlw_nwis_huc8;
 
   - changeSet:
@@ -130,7 +130,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_NWIS_ORGANIZATION' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_nwis_organization on prj_ml_weighting_swap_nwis(organization) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_nwis_organization on prj_ml_weighting_swap_nwis(organization) parallel 4 nologging;
         - rollback: drop index prjmlw_nwis_organization;
 
   - changeSet:
@@ -143,7 +143,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_NWIS_SITE' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_nwis_site on prj_ml_weighting_swap_nwis(site_id) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_nwis_site on prj_ml_weighting_swap_nwis(site_id) parallel 4 nologging;
         - rollback: drop index prjmlw_nwis_site;
 
   - changeSet:
@@ -156,7 +156,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_NWIS_SITE_TYPE' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_nwis_site_type on prj_ml_weighting_swap_nwis(site_type) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_nwis_site_type on prj_ml_weighting_swap_nwis(site_type) parallel 4 nologging;
         - rollback: drop index prjmlw_nwis_site_type;
 
   - changeSet:
@@ -169,7 +169,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_NWIS_STATE' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_nwis_state on prj_ml_weighting_swap_nwis(state_code) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_nwis_state on prj_ml_weighting_swap_nwis(state_code) parallel 4 nologging;
         - rollback: drop index prjmlw_nwis_state;
 
   - changeSet:
@@ -182,5 +182,5 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_NWIS_STATION' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_nwis_station on prj_ml_weighting_swap_nwis(station_id) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_nwis_station on prj_ml_weighting_swap_nwis(station_id) parallel 4 nologging;
         - rollback: drop index prjmlw_nwis_station;

--- a/stewards/indexes/prjMLWeighting.yml
+++ b/stewards/indexes/prjMLWeighting.yml
@@ -13,7 +13,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_STEWARDS_IDENTIFIER' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_stewards_identifier on prj_ml_weighting_swap_stewards(project_identifier) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_stewards_identifier on prj_ml_weighting_swap_stewards(project_identifier) parallel 4 nologging;
         - rollback: drop index prjmlw_stewards_identifier;
 
   - changeSet:
@@ -26,7 +26,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_STEWARDS_COUNTRY' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_stewards_country on prj_ml_weighting_swap_stewards(country_code) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_stewards_country on prj_ml_weighting_swap_stewards(country_code) parallel 4 nologging;
         - rollback: drop index prjmlw_stewards_country;
 
   - changeSet:
@@ -39,7 +39,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_STEWARDS_COUNTY' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_stewards_county on prj_ml_weighting_swap_stewards(county_code) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_stewards_county on prj_ml_weighting_swap_stewards(county_code) parallel 4 nologging;
         - rollback: drop index prjmlw_stewards_county;
 
   - changeSet:
@@ -52,7 +52,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_STEWARDS_HUC10' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_stewards_huc10 on prj_ml_weighting_swap_stewards(huc_10) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_stewards_huc10 on prj_ml_weighting_swap_stewards(huc_10) parallel 4 nologging;
         - rollback: drop index prjmlw_stewards_huc10;
 
   - changeSet:
@@ -65,7 +65,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_STEWARDS_HUC12' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_stewards_huc12 on prj_ml_weighting_swap_stewards(huc_12) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_stewards_huc12 on prj_ml_weighting_swap_stewards(huc_12) parallel 4 nologging;
         - rollback: drop index prjmlw_stewards_huc12;
 
   - changeSet:
@@ -78,7 +78,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_STEWARDS_HUC2' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_stewards_huc2 on prj_ml_weighting_swap_stewards(huc_2) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_stewards_huc2 on prj_ml_weighting_swap_stewards(huc_2) parallel 4 nologging;
         - rollback: drop index prjmlw_stewards_huc2;
 
   - changeSet:
@@ -91,7 +91,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_STEWARDS_HUC4' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_stewards_huc4 on prj_ml_weighting_swap_stewards(huc_4) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_stewards_huc4 on prj_ml_weighting_swap_stewards(huc_4) parallel 4 nologging;
         - rollback: drop index prjmlw_stewards_huc4;
 
   - changeSet:
@@ -104,7 +104,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_STEWARDS_HUC6' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_stewards_huc6 on prj_ml_weighting_swap_stewards(huc_6) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_stewards_huc6 on prj_ml_weighting_swap_stewards(huc_6) parallel 4 nologging;
         - rollback: drop index prjmlw_stewards_huc6;
 
   - changeSet:
@@ -117,7 +117,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_STEWARDS_HUC8' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_stewards_huc8 on prj_ml_weighting_swap_stewards(huc_8) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_stewards_huc8 on prj_ml_weighting_swap_stewards(huc_8) parallel 4 nologging;
         - rollback: drop index prjmlw_stewards_huc8;
 
   - changeSet:
@@ -130,7 +130,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_STEWARDS_ORGANIZATION' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_stewards_organization on prj_ml_weighting_swap_stewards(organization) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_stewards_organization on prj_ml_weighting_swap_stewards(organization) parallel 4 nologging;
         - rollback: drop index prjmlw_stewards_organization;
 
   - changeSet:
@@ -143,7 +143,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_STEWARDS_SITE' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_stewards_site on prj_ml_weighting_swap_stewards(site_id) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_stewards_site on prj_ml_weighting_swap_stewards(site_id) parallel 4 nologging;
         - rollback: drop index prjmlw_stewards_site;
 
   - changeSet:
@@ -156,7 +156,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_STEWARDS_SITE_TYPE' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_stewards_site_type on prj_ml_weighting_swap_stewards(site_type) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_stewards_site_type on prj_ml_weighting_swap_stewards(site_type) parallel 4 nologging;
         - rollback: drop index prjmlw_stewards_site_type;
 
   - changeSet:
@@ -169,7 +169,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_STEWARDS_STATE' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_stewards_state on prj_ml_weighting_swap_stewards(state_code) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_stewards_state on prj_ml_weighting_swap_stewards(state_code) parallel 4 nologging;
         - rollback: drop index prjmlw_stewards_state;
 
   - changeSet:
@@ -182,5 +182,5 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_STEWARDS_STATION' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_stewards_station on prj_ml_weighting_swap_stewards(station_id) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_stewards_station on prj_ml_weighting_swap_stewards(station_id) parallel 4 nologging;
         - rollback: drop index prjmlw_stewards_station;

--- a/storet/indexes/prjMLWeighting.yml
+++ b/storet/indexes/prjMLWeighting.yml
@@ -13,7 +13,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_STORET_IDENTIFIER' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_storet_identifier on prj_ml_weighting_swap_storet(project_identifier) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_storet_identifier on prj_ml_weighting_swap_storet(project_identifier) parallel 4 nologging;
         - rollback: drop index prjmlw_storet_identifier;
 
   - changeSet:
@@ -26,7 +26,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_STORET_COUNTRY' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_storet_country on prj_ml_weighting_swap_storet(country_code) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_storet_country on prj_ml_weighting_swap_storet(country_code) parallel 4 nologging;
         - rollback: drop index prjmlw_storet_country;
 
   - changeSet:
@@ -39,7 +39,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_STORET_COUNTY' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_storet_county on prj_ml_weighting_swap_storet(county_code) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_storet_county on prj_ml_weighting_swap_storet(county_code) parallel 4 nologging;
         - rollback: drop index prjmlw_storet_county;
 
   - changeSet:
@@ -52,7 +52,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_STORET_HUC10' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_storet_huc10 on prj_ml_weighting_swap_storet(huc_10) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_storet_huc10 on prj_ml_weighting_swap_storet(huc_10) parallel 4 nologging;
         - rollback: drop index prjmlw_storet_huc10;
 
   - changeSet:
@@ -65,7 +65,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_STORET_HUC12' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_storet_huc12 on prj_ml_weighting_swap_storet(huc_12) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_storet_huc12 on prj_ml_weighting_swap_storet(huc_12) parallel 4 nologging;
         - rollback: drop index prjmlw_storet_huc12;
 
   - changeSet:
@@ -78,7 +78,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_STORET_HUC2' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_storet_huc2 on prj_ml_weighting_swap_storet(huc_2) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_storet_huc2 on prj_ml_weighting_swap_storet(huc_2) parallel 4 nologging;
         - rollback: drop index prjmlw_storet_huc2;
 
   - changeSet:
@@ -91,7 +91,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_STORET_HUC4' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_storet_huc4 on prj_ml_weighting_swap_storet(huc_4) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_storet_huc4 on prj_ml_weighting_swap_storet(huc_4) parallel 4 nologging;
         - rollback: drop index prjmlw_storet_huc4;
 
   - changeSet:
@@ -104,7 +104,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_STORET_HUC6' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_storet_huc6 on prj_ml_weighting_swap_storet(huc_6) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_storet_huc6 on prj_ml_weighting_swap_storet(huc_6) parallel 4 nologging;
         - rollback: drop index prjmlw_storet_huc6;
 
   - changeSet:
@@ -117,7 +117,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_STORET_HUC8' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_storet_huc8 on prj_ml_weighting_swap_storet(huc_8) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_storet_huc8 on prj_ml_weighting_swap_storet(huc_8) parallel 4 nologging;
         - rollback: drop index prjmlw_storet_huc8;
 
   - changeSet:
@@ -130,7 +130,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_STORET_ORGANIZATION' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_storet_organization on prj_ml_weighting_swap_storet(organization) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_storet_organization on prj_ml_weighting_swap_storet(organization) parallel 4 nologging;
         - rollback: drop index prjmlw_storet_organization;
 
   - changeSet:
@@ -143,7 +143,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_STORET_SITE' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_storet_site on prj_ml_weighting_swap_storet(site_id) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_storet_site on prj_ml_weighting_swap_storet(site_id) parallel 4 nologging;
         - rollback: drop index prjmlw_storet_site;
 
   - changeSet:
@@ -156,7 +156,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_STORET_SITE_TYPE' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_storet_site_type on prj_ml_weighting_swap_storet(site_type) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_storet_site_type on prj_ml_weighting_swap_storet(site_type) parallel 4 nologging;
         - rollback: drop index prjmlw_storet_site_type;
 
   - changeSet:
@@ -169,7 +169,7 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_STORET_STATE' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_storet_state on prj_ml_weighting_swap_storet(state_code) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_storet_state on prj_ml_weighting_swap_storet(state_code) parallel 4 nologging;
         - rollback: drop index prjmlw_storet_state;
 
   - changeSet:
@@ -182,5 +182,5 @@ databaseChangeLog:
             expectedResult: 0
             sql: select count(*) from user_objects where object_name = 'PRJMLW_STORET_STATION' and object_type = 'INDEX';
       changes:
-        - sql: create bitmap index prjmlw_storet_station on prj_ml_weighting_swap_storet(station_id) local parallel 4 nologging;
+        - sql: create bitmap index prjmlw_storet_station on prj_ml_weighting_swap_storet(station_id) parallel 4 nologging;
         - rollback: drop index prjmlw_storet_station;


### PR DESCRIPTION
… local because the data-source-specific tables are not partitioned.