### PR TITLE
removed partitioning of publicSrsnames table and replaced version_id …

### DIFF
--- a/liquibase/changeLogs/wqp/schemaLoad/tables/publicSrsnames/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/publicSrsnames/changeLog.yml
@@ -17,19 +17,3 @@ databaseChangeLog:
             path: publicSrsnames.sql
             relativeToChangelogFile: true
         - rollback: drop table if exists ${WQP_SCHEMA_NAME}.public_srsnames cascade;
-
-  - changeSet:
-      author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.public_srsnames_current"
-      context: ci
-      preConditions:
-        - onFail: MARK_RAN
-        - onError: HALT
-        - not:
-          - tableExists:
-              tableName: public_srsnames_current
-      changes:
-        - sqlFile:
-            path: publicSrsnamesCurrent.sql
-            relativeToChangelogFile: true
-        - rollback: drop table if exists ${WQP_SCHEMA_NAME}.public_srsnames_current cascade;

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/publicSrsnames/publicSrsnames.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/publicSrsnames/publicSrsnames.sql
@@ -1,5 +1,5 @@
 create unlogged table if not exists ${WQP_SCHEMA_NAME}.public_srsnames
-(version_id                     smallint
+(data_source_id                 smallint
 ,parm_cd                        character varying (5)
 ,description                    character varying (170)
 ,characteristicname             character varying (1200)
@@ -13,5 +13,5 @@ create unlogged table if not exists ${WQP_SCHEMA_NAME}.public_srsnames
 ,last_rev_dt                    date
 ,max_last_rev_dt                date
 )
-partition by list (version_id)
+with (fillfactor = 100)
 ;


### PR DESCRIPTION
…with data_source_id. Initially this table will only be filled from the nwis etl so no need to partition.