### PR TITLE
add index for table join on project_dim and activity_sum (WQP-1590)

### DIFF
--- a/liquibase/changeLogs/wqp/schemaLoad/indexes/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/indexes/changeLog.yml
@@ -12,5 +12,9 @@ databaseChangeLog:
       relativeToChangelogFile: true
 
   - include:
+      file: "project_dim/changeLog.yml"
+      relativeToChangelogFile: true    
+
+  - include:
       file: "states/changeLog.yml"
       relativeToChangelogFile: true

--- a/liquibase/changeLogs/wqp/schemaLoad/indexes/project_dim/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/indexes/project_dim/changeLog.yml
@@ -1,0 +1,8 @@
+databaseChangeLog:
+  - preConditions:
+    - dbms:
+        type: postgresql
+
+  - include:
+      file: "project_dim.yml"
+      relativeToChangelogFile: true

--- a/liquibase/changeLogs/wqp/schemaLoad/indexes/project_dim/project_dim.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/indexes/project_dim/project_dim.yml
@@ -1,0 +1,18 @@
+databaseChangeLog:
+  - preConditions:
+    - dbms:
+        type: postgresql
+
+  - changeSet:
+      author: kkehl
+      id: "create.index.${WQP_SCHEMA_NAME}.project_dim_data_source_id_idx"
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - not:
+          - indexExists:
+              WQP_SCHEMA_NAME: ${WQP_SCHEMA_NAME}
+              indexName: project_dim_data_source_id_idx
+      changes:
+        - sql: create index if not exists project_dim_data_source_id_idx on ${WQP_SCHEMA_NAME}.project_dim(data_source_id);
+        - rollback: drop index if exists ${WQP_SCHEMA_NAME}.project_dim_data_source_id_idx;


### PR DESCRIPTION
Pull Request #308 in WQP-WQX-Services added two table joins as indicated below.  One of the table joins is okay because project_id and project_dim_value are both indexed columns.  The other table join is causing a performance issue because there is no index on project_dim.data_source_id.   Add this index.


where (prime.data_source_id,project_id) in
  (select data_source_id,project_dim_value
     from project_dim
       where project_dim.data_source_id = prime.data_source_id
         and project_dim.project_dim_value = prime.project_id
         and code_value in ('National Water Quality Assessment Program (NAWQA)')
   )
