### PR TITLE
WQP-1592 (Drop "unlogged" keyword from all WQP tables)

### DIFF
--- a/liquibase/changeLogs/wqp/schemaLoad/tables/county/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/county/changeLog.yml
@@ -84,7 +84,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.us_counties_dis_20121015"
+      id: "create.table.${WQP_SCHEMA_NAME}.us_counties_dis_20121015.v2"
       preConditions:
         - onFail: MARK_RAN
         - onError: HALT
@@ -115,7 +115,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.tl_2019_us_county_geopkg"
+      id: "create.table.${WQP_SCHEMA_NAME}.tl_2019_us_county_geopkg.v2"
       preConditions:
         - onFail: MARK_RAN
         - onError: HALT

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/county/tl2019UsCountyGeopkg.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/county/tl2019UsCountyGeopkg.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.tl_2019_us_county_geopkg
+create table if not exists ${WQP_SCHEMA_NAME}.tl_2019_us_county_geopkg
 (objectid                         serial
 ,statefp                          character varying(2)
 ,countyfp                         character varying(3)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/county/usCountiesDis20121015.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/county/usCountiesDis20121015.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.us_counties_dis_20121015
+create table if not exists ${WQP_SCHEMA_NAME}.us_counties_dis_20121015
 (fips                           character varying (5)
 ,area                           numeric
 ,perimeter                      numeric


### PR DESCRIPTION
   Removed unlogged from usCountiesDis20121015.sql
   Removed unlogged from tl2019UsCountyGeopkg.sql
   Updated id to version v2 for the create changeLogs

The approach taken here is that, since us_counties_dis_20121015 is
a regular table with no partitions (fairly small, 47M currently on test),
the setting of the table to logged can be done separately using a single
sql command one time for the existing databases. Going forward when this is
used to create the table, the table will be in the desired state.
No need to maintain a separate lquidbase script.