### PR TITLE
WQP-1592 (Drop "unlogged" keyword from all WQP tables)

### DIFF
--- a/liquibase/changeLogs/wqp/schemaLoad/tables/dataSource/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/dataSource/changeLog.yml
@@ -33,5 +33,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${WQP_SCHEMA_NAME}.data_source set logged
-        - rollback: alter table if exists ${WQP_SCHEMA_NAME}.data_source set unlogged
 

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/etlThreshold/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/etlThreshold/changeLog.yml
@@ -33,5 +33,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${WQP_SCHEMA_NAME}.etl_threshold set logged
-        - rollback: alter table if exists ${WQP_SCHEMA_NAME}.etl_threshold set unlogged
 

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/huc/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/huc/changeLog.yml
@@ -48,7 +48,6 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${WQP_SCHEMA_NAME}.huc12nometa set logged
-        - rollback: alter table if exists ${WQP_SCHEMA_NAME}.huc12nometa set unlogged
 
   - changeSet:
       author: eorosz
@@ -65,5 +64,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${WQP_SCHEMA_NAME}.huc8_conus_hi_ak_pr_dis set logged
-        - rollback: alter table if exists ${WQP_SCHEMA_NAME}.huc8_conus_hi_ak_pr_dis set unlogged
 

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/lastEtl/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/lastEtl/changeLog.yml
@@ -33,5 +33,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${WQP_SCHEMA_NAME}.last_etl set logged
-        - rollback: alter table if exists ${WQP_SCHEMA_NAME}.last_etl set unlogged
 

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/publicSrsnames/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/publicSrsnames/changeLog.yml
@@ -33,7 +33,6 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${WQP_SCHEMA_NAME}.public_srsnames set logged
-        - rollback: alter table if exists ${WQP_SCHEMA_NAME}.public_srsnames set unlogged
 
   - changeSet:
       author: eorosz
@@ -50,5 +49,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${WQP_SCHEMA_NAME}.public_srsnames_current set logged
-        - rollback: alter table if exists ${WQP_SCHEMA_NAME}.public_srsnames_current set unlogged
 


### PR DESCRIPTION
   Removed rollback for the set logging changesets.
Because why, why, why do we want to rollback to a
state we are trying to get rid of?