### PR TITLE
WQP-1592 (Drop "unlogged" keyword from all WQP tables)

### DIFF
--- a/liquibase/changeLogs/wqp/schemaLoad/tables/actMetric/actMetricNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/actMetric/actMetricNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.act_metric_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.act_metric_nwis
 partition of ${WQP_SCHEMA_NAME}.act_metric
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/actMetric/actMetricStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/actMetric/actMetricStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.act_metric_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.act_metric_stewards
 partition of ${WQP_SCHEMA_NAME}.act_metric
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/actMetric/actMetricStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/actMetric/actMetricStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.act_metric_storet
+create table if not exists ${WQP_SCHEMA_NAME}.act_metric_storet
 partition of ${WQP_SCHEMA_NAME}.act_metric
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/actMetric/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/actMetric/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.act_metric.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.act_metric.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.act_metric.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.act_metric.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.act_metric.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.act_metric.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/activity/activityNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/activity/activityNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.activity_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.activity_nwis
 partition of ${WQP_SCHEMA_NAME}.activity
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/activity/activityStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/activity/activityStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.activity_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.activity_stewards
 partition of ${WQP_SCHEMA_NAME}.activity
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/activity/activityStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/activity/activityStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.activity_storet
+create table if not exists ${WQP_SCHEMA_NAME}.activity_storet
 partition of ${WQP_SCHEMA_NAME}.activity
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/activity/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/activity/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.activity.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.activity.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.activity.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.activity.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.activity.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.activity.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/activityObject/activityObjectNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/activityObject/activityObjectNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.activity_object_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.activity_object_nwis
 partition of ${WQP_SCHEMA_NAME}.activity_object
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/activityObject/activityObjectStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/activityObject/activityObjectStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.activity_object_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.activity_object_stewards
 partition of ${WQP_SCHEMA_NAME}.activity_object
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/activityObject/activityObjectStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/activityObject/activityObjectStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.activity_object_storet
+create table if not exists ${WQP_SCHEMA_NAME}.activity_object_storet
 partition of ${WQP_SCHEMA_NAME}.activity_object
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/activityObject/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/activityObject/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.activity_object.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.activity_object.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.activity_object.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.activity_object.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.activity_object.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.activity_object.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/activitySum/activitySumNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/activitySum/activitySumNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.activity_sum_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.activity_sum_nwis
 partition of ${WQP_SCHEMA_NAME}.activity_sum
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/activitySum/activitySumStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/activitySum/activitySumStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.activity_sum_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.activity_sum_stewards
 partition of ${WQP_SCHEMA_NAME}.activity_sum
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/activitySum/activitySumStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/activitySum/activitySumStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.activity_sum_storet
+create table if not exists ${WQP_SCHEMA_NAME}.activity_sum_storet
 partition of ${WQP_SCHEMA_NAME}.activity_sum
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/activitySum/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/activitySum/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.activity_sum.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.activity_sum.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.activity_sum.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.activity_sum.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.activity_sum.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.activity_sum.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/assemblage/assemblageNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/assemblage/assemblageNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.assemblage_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.assemblage_nwis
 partition of ${WQP_SCHEMA_NAME}.assemblage
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/assemblage/assemblageStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/assemblage/assemblageStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.assemblage_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.assemblage_stewards
 partition of ${WQP_SCHEMA_NAME}.assemblage
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/assemblage/assemblageStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/assemblage/assemblageStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.assemblage_storet
+create table if not exists ${WQP_SCHEMA_NAME}.assemblage_storet
 partition of ${WQP_SCHEMA_NAME}.assemblage
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/assemblage/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/assemblage/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.assemblage.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.assemblage.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.assemblage.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.assemblage.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.assemblage.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.assemblage.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/bioHabMetric/bioHabMetricNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/bioHabMetric/bioHabMetricNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.bio_hab_metric_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.bio_hab_metric_nwis
 partition of ${WQP_SCHEMA_NAME}.bio_hab_metric
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/bioHabMetric/bioHabMetricStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/bioHabMetric/bioHabMetricStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.bio_hab_metric_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.bio_hab_metric_stewards
 partition of ${WQP_SCHEMA_NAME}.bio_hab_metric
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/bioHabMetric/bioHabMetricStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/bioHabMetric/bioHabMetricStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.bio_hab_metric_storet
+create table if not exists ${WQP_SCHEMA_NAME}.bio_hab_metric_storet
 partition of ${WQP_SCHEMA_NAME}.bio_hab_metric
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/bioHabMetric/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/bioHabMetric/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.bio_hab_metric.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.bio_hab_metric.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.bio_hab_metric.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.bio_hab_metric.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.bio_hab_metric.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.bio_hab_metric.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/charName/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/charName/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.char_name.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.char_name.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.char_name.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.char_name.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.char_name.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.char_name.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/charName/charNameNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/charName/charNameNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.char_name_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.char_name_nwis
 partition of ${WQP_SCHEMA_NAME}.char_name
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/charName/charNameStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/charName/charNameStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.char_name_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.char_name_stewards
 partition of ${WQP_SCHEMA_NAME}.char_name
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/charName/charNameStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/charName/charNameStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.char_name_storet
+create table if not exists ${WQP_SCHEMA_NAME}.char_name_storet
 partition of ${WQP_SCHEMA_NAME}.char_name
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/charType/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/charType/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.char_type.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.char_type.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.char_type.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.char_type.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.char_type.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.char_type.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/charType/charTypeNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/charType/charTypeNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.char_type_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.char_type_nwis
 partition of ${WQP_SCHEMA_NAME}.char_type
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/charType/charTypeStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/charType/charTypeStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.char_type_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.char_type_stewards
 partition of ${WQP_SCHEMA_NAME}.char_type
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/charType/charTypeStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/charType/charTypeStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.char_type_storet
+create table if not exists ${WQP_SCHEMA_NAME}.char_type_storet
 partition of ${WQP_SCHEMA_NAME}.char_type
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/country/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/country/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.country.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.country.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.country.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.country.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.country.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.country.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/country/countryNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/country/countryNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.country_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.country_nwis
 partition of ${WQP_SCHEMA_NAME}.country
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/country/countryStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/country/countryStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.country_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.country_stewards
 partition of ${WQP_SCHEMA_NAME}.country
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/country/countryStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/country/countryStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.country_storet
+create table if not exists ${WQP_SCHEMA_NAME}.country_storet
 partition of ${WQP_SCHEMA_NAME}.country
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/county/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/county/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.county.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.county.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.county.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.county.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.county.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.county.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -84,7 +84,7 @@ databaseChangeLog:
 
   - changeSet:
       author: ssoper
-      id: "create.table.${WQP_SCHEMA_NAME}.county_geom"
+      id: "create.table.${WQP_SCHEMA_NAME}.county_geom.v2"
       preConditions:
         - onFail: MARK_RAN
         - onError: HALT

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/county/countyGeom.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/county/countyGeom.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.county_geom
+create table if not exists ${WQP_SCHEMA_NAME}.county_geom
 (fips_county_code                 character varying (3)
 ,county_name                      character varying (256)
 ,geom                             geometry

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/county/countyNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/county/countyNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.county_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.county_nwis
 partition of ${WQP_SCHEMA_NAME}.county
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/county/countyStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/county/countyStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.county_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.county_stewards
 partition of ${WQP_SCHEMA_NAME}.county
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/county/countyStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/county/countyStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.county_storet
+create table if not exists ${WQP_SCHEMA_NAME}.county_storet
 partition of ${WQP_SCHEMA_NAME}.county
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/dataSource/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/dataSource/changeLog.yml
@@ -5,7 +5,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.data_source"
+      id: "create.table.${WQP_SCHEMA_NAME}.data_source.v2"
       preConditions:
         - onFail: MARK_RAN
         - onError: HALT

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/dataSource/dataSource.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/dataSource/dataSource.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.data_source
+create table if not exists ${WQP_SCHEMA_NAME}.data_source
 (data_source_id                 smallint
 ,text                           character varying (8)
 ,primary key (data_source_id)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/etlThreshold/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/etlThreshold/changeLog.yml
@@ -5,7 +5,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.etl_threshold"
+      id: "create.table.${WQP_SCHEMA_NAME}.etl_threshold.v2"
       preConditions:
         - onFail: MARK_RAN
         - onError: HALT

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/etlThreshold/etlThreshold.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/etlThreshold/etlThreshold.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.etl_threshold
+create table if not exists ${WQP_SCHEMA_NAME}.etl_threshold
 (data_source_id                 smallint
 ,table_name                     character varying (30)
 ,min_rows                       integer

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/huc/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/huc/changeLog.yml
@@ -5,7 +5,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.huc8_conus_hi_ak_pr_dis"
+      id: "create.table.${WQP_SCHEMA_NAME}.huc8_conus_hi_ak_pr_dis.v2"
       preConditions:
         - onFail: MARK_RAN
         - onError: HALT
@@ -20,7 +20,7 @@ databaseChangeLog:
 
   - changeSet:
       author: skaymen
-      id: "create.table.${WQP_SCHEMA_NAME}.huc12nometa"
+      id: "create.table.${WQP_SCHEMA_NAME}.huc12nometa.v2"
       preConditions:
         - onFail: MARK_RAN
         - onError: HALT

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/huc/huc12nometa.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/huc/huc12nometa.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.huc12nometa
+create table if not exists ${WQP_SCHEMA_NAME}.huc12nometa
 (objectid                       numeric
 ,huc12                          character varying (12)
 ,geometry                       geometry

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/huc/huc8ConusHiAkPrDis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/huc/huc8ConusHiAkPrDis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.huc8_conus_hi_ak_pr_dis
+create table if not exists ${WQP_SCHEMA_NAME}.huc8_conus_hi_ak_pr_dis
 (cat_num                        character varying (8)
 ,first_cat_                     character varying (60)
 ,geom                           geometry

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/lastEtl/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/lastEtl/changeLog.yml
@@ -5,7 +5,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.last_etl"
+      id: "create.table.${WQP_SCHEMA_NAME}.last_etl.v2"
       preConditions:
         - onFail: MARK_RAN
         - onError: HALT

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/lastEtl/lastEtl.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/lastEtl/lastEtl.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.last_etl
+create table if not exists ${WQP_SCHEMA_NAME}.last_etl
 (data_source_id                 smallint
 ,completed_utc                  timestamp
 )

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/mlGrouping/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/mlGrouping/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.ml_grouping.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.ml_grouping.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.ml_grouping.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.ml_grouping.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.ml_grouping.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.ml_grouping.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/mlGrouping/mlGroupingNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/mlGrouping/mlGroupingNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.ml_grouping_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.ml_grouping_nwis
 partition of ${WQP_SCHEMA_NAME}.ml_grouping
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/mlGrouping/mlGroupingStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/mlGrouping/mlGroupingStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.ml_grouping_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.ml_grouping_stewards
 partition of ${WQP_SCHEMA_NAME}.ml_grouping
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/mlGrouping/mlGroupingStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/mlGrouping/mlGroupingStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.ml_grouping_storet
+create table if not exists ${WQP_SCHEMA_NAME}.ml_grouping_storet
 partition of ${WQP_SCHEMA_NAME}.ml_grouping
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/monitoringLoc/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/monitoringLoc/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.monitoring_loc.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.monitoring_loc.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.monitoring_loc.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.monitoring_loc.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.monitoring_loc.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.monitoring_loc.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/monitoringLoc/monitoringLocNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/monitoringLoc/monitoringLocNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.monitoring_loc_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.monitoring_loc_nwis
 partition of ${WQP_SCHEMA_NAME}.monitoring_loc
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/monitoringLoc/monitoringLocStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/monitoringLoc/monitoringLocStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.monitoring_loc_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.monitoring_loc_stewards
 partition of ${WQP_SCHEMA_NAME}.monitoring_loc
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/monitoringLoc/monitoringLocStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/monitoringLoc/monitoringLocStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.monitoring_loc_storet
+create table if not exists ${WQP_SCHEMA_NAME}.monitoring_loc_storet
 partition of ${WQP_SCHEMA_NAME}.monitoring_loc
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/orgData/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/orgData/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.org_data.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.org_data.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.org_data.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.org_data.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.org_data.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.org_data.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/orgData/orgDataNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/orgData/orgDataNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.org_data_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.org_data_nwis
 partition of ${WQP_SCHEMA_NAME}.org_data
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/orgData/orgDataStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/orgData/orgDataStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.org_data_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.org_data_stewards
 partition of ${WQP_SCHEMA_NAME}.org_data
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/orgData/orgDataStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/orgData/orgDataStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.org_data_storet
+create table if not exists ${WQP_SCHEMA_NAME}.org_data_storet
 partition of ${WQP_SCHEMA_NAME}.org_data
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/orgGrouping/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/orgGrouping/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.org_grouping.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.org_grouping.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.org_grouping.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.org_grouping.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.org_grouping.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.org_grouping.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/orgGrouping/orgGroupingNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/orgGrouping/orgGroupingNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.org_grouping_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.org_grouping_nwis
 partition of ${WQP_SCHEMA_NAME}.org_grouping
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/orgGrouping/orgGroupingStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/orgGrouping/orgGroupingStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.org_grouping_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.org_grouping_stewards
 partition of ${WQP_SCHEMA_NAME}.org_grouping
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/orgGrouping/orgGroupingStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/orgGrouping/orgGroupingStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.org_grouping_storet
+create table if not exists ${WQP_SCHEMA_NAME}.org_grouping_storet
 partition of ${WQP_SCHEMA_NAME}.org_grouping
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/organization/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/organization/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.organization.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.organization.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.organization.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.organization.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.organization.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.organization.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/organization/organizationNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/organization/organizationNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.organization_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.organization_nwis
 partition of ${WQP_SCHEMA_NAME}.organization
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/organization/organizationStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/organization/organizationStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.organization_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.organization_stewards
 partition of ${WQP_SCHEMA_NAME}.organization
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/organization/organizationStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/organization/organizationStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.organization_storet
+create table if not exists ${WQP_SCHEMA_NAME}.organization_storet
 partition of ${WQP_SCHEMA_NAME}.organization
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/organizationSum/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/organizationSum/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.organization_sum.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.organization_sum.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.organization_sum.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.organization_sum.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.organization_sum.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.organization_sum.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/organizationSum/organizationSumNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/organizationSum/organizationSumNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.organization_sum_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.organization_sum_nwis
 partition of ${WQP_SCHEMA_NAME}.organization_sum
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/organizationSum/organizationSumStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/organizationSum/organizationSumStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.organization_sum_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.organization_sum_stewards
 partition of ${WQP_SCHEMA_NAME}.organization_sum
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/organizationSum/organizationSumStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/organizationSum/organizationSumStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.organization_sum_storet
+create table if not exists ${WQP_SCHEMA_NAME}.organization_sum_storet
 partition of ${WQP_SCHEMA_NAME}.organization_sum
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/prjMLWeighting/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/prjMLWeighting/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.prj_ml_weighting.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.prj_ml_weighting.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.prj_ml_weighting.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.prj_ml_weighting.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.prj_ml_weighting.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.prj_ml_weighting.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/prjMLWeighting/prjMLWeightingNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/prjMLWeighting/prjMLWeightingNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.prj_ml_weighting_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.prj_ml_weighting_nwis
 partition of ${WQP_SCHEMA_NAME}.prj_ml_weighting
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/prjMLWeighting/prjMLWeightingStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/prjMLWeighting/prjMLWeightingStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.prj_ml_weighting_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.prj_ml_weighting_stewards
 partition of ${WQP_SCHEMA_NAME}.prj_ml_weighting
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/prjMLWeighting/prjMLWeightingStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/prjMLWeighting/prjMLWeightingStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.prj_ml_weighting_storet
+create table if not exists ${WQP_SCHEMA_NAME}.prj_ml_weighting_storet
 partition of ${WQP_SCHEMA_NAME}.prj_ml_weighting
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/project/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/project/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.project.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.project.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.project.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.project.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.project.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.project.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/project/projectNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/project/projectNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.project_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.project_nwis
 partition of ${WQP_SCHEMA_NAME}.project
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/project/projectStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/project/projectStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.project_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.project_stewards
 partition of ${WQP_SCHEMA_NAME}.project
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/project/projectStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/project/projectStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.project_storet
+create table if not exists ${WQP_SCHEMA_NAME}.project_storet
 partition of ${WQP_SCHEMA_NAME}.project
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/projectData/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/projectData/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.project_data.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.project_data.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.project_data.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.project_data.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.project_data.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.project_data.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/projectData/projectDataNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/projectData/projectDataNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.project_data_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.project_data_nwis
 partition of ${WQP_SCHEMA_NAME}.project_data
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/projectData/projectDataStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/projectData/projectDataStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.project_data_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.project_data_stewards
 partition of ${WQP_SCHEMA_NAME}.project_data
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/projectData/projectDataStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/projectData/projectDataStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.project_data_storet
+create table if not exists ${WQP_SCHEMA_NAME}.project_data_storet
 partition of ${WQP_SCHEMA_NAME}.project_data
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/projectDim/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/projectDim/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.project_dim.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.project_dim.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.project_dim.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.project_dim.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.project_dim.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.project_dim.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/projectDim/projectDimNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/projectDim/projectDimNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.project_dim_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.project_dim_nwis
 partition of ${WQP_SCHEMA_NAME}.project_dim
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/projectDim/projectDimStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/projectDim/projectDimStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.project_dim_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.project_dim_stewards
 partition of ${WQP_SCHEMA_NAME}.project_dim
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/projectDim/projectDimStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/projectDim/projectDimStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.project_dim_storet
+create table if not exists ${WQP_SCHEMA_NAME}.project_dim_storet
 partition of ${WQP_SCHEMA_NAME}.project_dim
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/projectObject/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/projectObject/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.project_object.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.project_object.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.project_object.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.project_object.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.project_object.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.project_object.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/projectObject/projectObjectNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/projectObject/projectObjectNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.project_object_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.project_object_nwis
 partition of ${WQP_SCHEMA_NAME}.project_object
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/projectObject/projectObjectStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/projectObject/projectObjectStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.project_object_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.project_object_stewards
 partition of ${WQP_SCHEMA_NAME}.project_object
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/projectObject/projectObjectStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/projectObject/projectObjectStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.project_object_storet
+create table if not exists ${WQP_SCHEMA_NAME}.project_object_storet
 partition of ${WQP_SCHEMA_NAME}.project_object
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/publicSrsnames/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/publicSrsnames/changeLog.yml
@@ -5,7 +5,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.public_srsnames"
+      id: "create.table.${WQP_SCHEMA_NAME}.public_srsnames.v2"
       preConditions:
         - onFail: MARK_RAN
         - onError: HALT

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/publicSrsnames/publicSrsnames.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/publicSrsnames/publicSrsnames.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.public_srsnames
+create table if not exists ${WQP_SCHEMA_NAME}.public_srsnames
 (data_source_id                 smallint
 ,parm_cd                        character varying (5)
 ,description                    character varying (170)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/publicSrsnames/publicSrsnamesCurrent.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/publicSrsnames/publicSrsnamesCurrent.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.public_srsnames_current
+create table if not exists ${WQP_SCHEMA_NAME}.public_srsnames_current
 partition of ${WQP_SCHEMA_NAME}.public_srsnames
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/qwportalSummary/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/qwportalSummary/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.qwportal_summary.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.qwportal_summary.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.qwportal_summary.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.qwportal_summary.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.qwportal_summary.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.qwportal_summary.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/qwportalSummary/qwportalSummaryNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/qwportalSummary/qwportalSummaryNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.qwportal_summary_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.qwportal_summary_nwis
 partition of ${WQP_SCHEMA_NAME}.qwportal_summary
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/qwportalSummary/qwportalSummaryStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/qwportalSummary/qwportalSummaryStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.qwportal_summary_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.qwportal_summary_stewards
 partition of ${WQP_SCHEMA_NAME}.qwportal_summary
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/qwportalSummary/qwportalSummaryStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/qwportalSummary/qwportalSummaryStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.qwportal_summary_storet
+create table if not exists ${WQP_SCHEMA_NAME}.qwportal_summary_storet
 partition of ${WQP_SCHEMA_NAME}.qwportal_summary
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/rDetectQntLmt/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/rDetectQntLmt/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.r_detect_qnt_lmt.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.r_detect_qnt_lmt.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.r_detect_qnt_lmt.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.r_detect_qnt_lmt.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.r_detect_qnt_lmt.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.r_detect_qnt_lmt.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/rDetectQntLmt/rDetectQntLmtNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/rDetectQntLmt/rDetectQntLmtNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.r_detect_qnt_lmt_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.r_detect_qnt_lmt_nwis
 partition of ${WQP_SCHEMA_NAME}.r_detect_qnt_lmt
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/rDetectQntLmt/rDetectQntLmtStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/rDetectQntLmt/rDetectQntLmtStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.r_detect_qnt_lmt_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.r_detect_qnt_lmt_stewards
 partition of ${WQP_SCHEMA_NAME}.r_detect_qnt_lmt
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/rDetectQntLmt/rDetectQntLmtStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/rDetectQntLmt/rDetectQntLmtStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.r_detect_qnt_lmt_storet
+create table if not exists ${WQP_SCHEMA_NAME}.r_detect_qnt_lmt_storet
 partition of ${WQP_SCHEMA_NAME}.r_detect_qnt_lmt
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/result/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/result/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.result.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.result.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.result.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.result.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.result.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.result.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/result/resultNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/result/resultNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.result_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.result_nwis
 partition of ${WQP_SCHEMA_NAME}.result
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/result/resultStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/result/resultStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.result_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.result_stewards
 partition of ${WQP_SCHEMA_NAME}.result
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/result/resultStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/result/resultStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.result_storet
+create table if not exists ${WQP_SCHEMA_NAME}.result_storet
 partition of ${WQP_SCHEMA_NAME}.result
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/resultObject/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/resultObject/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.result_object.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.result_object.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.result_object.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.result_object.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.result_object.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.result_object.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/resultObject/resultObjectNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/resultObject/resultObjectNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.result_object_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.result_object_nwis
 partition of ${WQP_SCHEMA_NAME}.result_object
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/resultObject/resultObjectStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/resultObject/resultObjectStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.result_object_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.result_object_stewards
 partition of ${WQP_SCHEMA_NAME}.result_object
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/resultObject/resultObjectStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/resultObject/resultObjectStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.result_object_storet
+create table if not exists ${WQP_SCHEMA_NAME}.result_object_storet
 partition of ${WQP_SCHEMA_NAME}.result_object
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/resultSum/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/resultSum/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.result_sum.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.result_sum.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.result_sum.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.result_sum.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.result_sum.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.result_sum.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/resultSum/resultSumNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/resultSum/resultSumNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.result_sum_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.result_sum_nwis
 partition of ${WQP_SCHEMA_NAME}.result_sum
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/resultSum/resultSumStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/resultSum/resultSumStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.result_sum_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.result_sum_stewards
 partition of ${WQP_SCHEMA_NAME}.result_sum
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/resultSum/resultSumStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/resultSum/resultSumStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.result_sum_storet
+create table if not exists ${WQP_SCHEMA_NAME}.result_sum_storet
 partition of ${WQP_SCHEMA_NAME}.result_sum
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/sampleMedia/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/sampleMedia/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.sample_media.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.sample_media.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.sample_media.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.sample_media.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.sample_media.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.sample_media.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/sampleMedia/sampleMediaNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/sampleMedia/sampleMediaNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.sample_media_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.sample_media_nwis
 partition of ${WQP_SCHEMA_NAME}.sample_media
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/sampleMedia/sampleMediaStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/sampleMedia/sampleMediaStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.sample_media_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.sample_media_stewards
 partition of ${WQP_SCHEMA_NAME}.sample_media
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/sampleMedia/sampleMediaStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/sampleMedia/sampleMediaStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.sample_media_storet
+create table if not exists ${WQP_SCHEMA_NAME}.sample_media_storet
 partition of ${WQP_SCHEMA_NAME}.sample_media
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/siteType/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/siteType/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.site_type.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.site_type.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.site_type.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.site_type.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.site_type.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.site_type.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/siteType/siteTypeNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/siteType/siteTypeNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.site_type_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.site_type_nwis
 partition of ${WQP_SCHEMA_NAME}.site_type
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/siteType/siteTypeStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/siteType/siteTypeStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.site_type_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.site_type_stewards
 partition of ${WQP_SCHEMA_NAME}.site_type
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/siteType/siteTypeStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/siteType/siteTypeStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.site_type_storet
+create table if not exists ${WQP_SCHEMA_NAME}.site_type_storet
 partition of ${WQP_SCHEMA_NAME}.site_type
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/state/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/state/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.state.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.state.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.state.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.state.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.state.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.state.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -69,7 +69,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.states"
+      id: "create.table.${WQP_SCHEMA_NAME}.states.v2"
       preConditions:
         - onFail: MARK_RAN
         - onError: HALT

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/state/stateNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/state/stateNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.state_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.state_nwis
 partition of ${WQP_SCHEMA_NAME}.state
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/state/stateStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/state/stateStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.state_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.state_stewards
 partition of ${WQP_SCHEMA_NAME}.state
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/state/stateStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/state/stateStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.state_storet
+create table if not exists ${WQP_SCHEMA_NAME}.state_storet
 partition of ${WQP_SCHEMA_NAME}.state
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/state/states.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/state/states.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.states
+create table if not exists ${WQP_SCHEMA_NAME}.states
 (state                          character varying (26)
 ,state_abrv                     character varying (2)
 ,fipsst                         character varying (2)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/station/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/station/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.station.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.station.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.station.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.station.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.station.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.station.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/station/stationNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/station/stationNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.station_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.station_nwis
 partition of ${WQP_SCHEMA_NAME}.station
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/station/stationStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/station/stationStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.station_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.station_stewards
 partition of ${WQP_SCHEMA_NAME}.station
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/station/stationStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/station/stationStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.station_storet
+create table if not exists ${WQP_SCHEMA_NAME}.station_storet
 partition of ${WQP_SCHEMA_NAME}.station
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/stationObject/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/stationObject/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.station_object.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.station_object.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.station_object.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.station_object.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.station_object.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.station_object.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/stationObject/stationObjectNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/stationObject/stationObjectNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.station_object_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.station_object_nwis
 partition of ${WQP_SCHEMA_NAME}.station_object
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/stationObject/stationObjectStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/stationObject/stationObjectStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.station_object_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.station_object_stewards
 partition of ${WQP_SCHEMA_NAME}.station_object
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/stationObject/stationObjectStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/stationObject/stationObjectStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.station_object_storet
+create table if not exists ${WQP_SCHEMA_NAME}.station_object_storet
 partition of ${WQP_SCHEMA_NAME}.station_object
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/stationSum/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/stationSum/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.station_sum.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.station_sum.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.station_sum.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.station_sum.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.station_sum.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.station_sum.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/stationSum/stationSumNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/stationSum/stationSumNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.station_sum_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.station_sum_nwis
 partition of ${WQP_SCHEMA_NAME}.station_sum
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/stationSum/stationSumStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/stationSum/stationSumStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.station_sum_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.station_sum_stewards
 partition of ${WQP_SCHEMA_NAME}.station_sum
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/stationSum/stationSumStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/stationSum/stationSumStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.station_sum_storet
+create table if not exists ${WQP_SCHEMA_NAME}.station_sum_storet
 partition of ${WQP_SCHEMA_NAME}.station_sum
 for values in (3)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/taxaName/changeLog.yml
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/taxaName/changeLog.yml
@@ -21,7 +21,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.taxa_name.partition.nwis"
+      id: "create.table.${WQP_SCHEMA_NAME}.taxa_name.partition.nwis.v2"
       context: (external or internal) and ci
       preConditions:
         - onFail: MARK_RAN
@@ -37,7 +37,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.taxa_name.partition.stewards"
+      id: "create.table.${WQP_SCHEMA_NAME}.taxa_name.partition.stewards.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN
@@ -53,7 +53,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQP_SCHEMA_NAME}.taxa_name.partition.storet"
+      id: "create.table.${WQP_SCHEMA_NAME}.taxa_name.partition.storet.v2"
       context: external and ci
       preConditions:
         - onFail: MARK_RAN

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/taxaName/taxaNameNwis.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/taxaName/taxaNameNwis.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.taxa_name_nwis
+create table if not exists ${WQP_SCHEMA_NAME}.taxa_name_nwis
 partition of ${WQP_SCHEMA_NAME}.taxa_name
 for values in (2)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/taxaName/taxaNameStewards.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/taxaName/taxaNameStewards.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.taxa_name_stewards
+create table if not exists ${WQP_SCHEMA_NAME}.taxa_name_stewards
 partition of ${WQP_SCHEMA_NAME}.taxa_name
 for values in (1)
 with (fillfactor = 100)

--- a/liquibase/changeLogs/wqp/schemaLoad/tables/taxaName/taxaNameStoret.sql
+++ b/liquibase/changeLogs/wqp/schemaLoad/tables/taxaName/taxaNameStoret.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQP_SCHEMA_NAME}.taxa_name_storet
+create table if not exists ${WQP_SCHEMA_NAME}.taxa_name_storet
 partition of ${WQP_SCHEMA_NAME}.taxa_name
 for values in (3)
 with (fillfactor = 100)


### PR DESCRIPTION
   Updated the sql scripts to create tables/partitions logged.
   Updated liquidbase create scripts to version 2 id.
This allows the changeLog that alter the tables to logged to be
removed after all the existing databases have been migrated
(since the tables will be logged from the beginning).